### PR TITLE
Reduce AWS SDK updates to once a month

### DIFF
--- a/go-default.json
+++ b/go-default.json
@@ -15,6 +15,11 @@
     {
       "matchManagers": ["gomod"],
       "digest": { "masterIssueApproval": true }
+    },
+    {
+      "matchDatasources": ["go"],
+      "matchPackagePrefixes": ["github.com/aws/aws-sdk-go-v2"],
+      "schedule": "before 3am on the first day of the month"
     }
   ]
 }


### PR DESCRIPTION
These packages update continuously, so try to slow how often we get notified.